### PR TITLE
Find all executables of the crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "cargo-valgrind"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,4 +3,87 @@
 [[package]]
 name = "cargo-valgrind"
 version = "0.1.0"
+dependencies = [
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[[package]]
+name = "itoa"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+"checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+"checksum serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113"
+"checksum serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "01e69e1b8a631f245467ee275b8c757b818653c6d704cdbcaeb56b56767b529c"
+"checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
+"checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-valgrind"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Julian Frimmel <julian.frimmel@gmail.com>"]
 edition = "2018"
 description = "A cargo subcommand for running valgrind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,9 @@ categories = [
 name = "cargo-valgrind"
 path = "src/bin/main.rs"
 
-[dependencies]
+[dependencies.serde]
+version = "1.0"
+features = ["derive"]
+
+[dependencies.serde_json]
+version = "1.0"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,7 @@
-use cargo_valgrind::binaries;
+use cargo_valgrind::{binaries, Build};
 
 fn main() {
-    for binary in binaries("Cargo.toml").unwrap() {
+    for binary in binaries("Cargo.toml", Build::Debug).unwrap() {
         println!("{}", binary.to_str().unwrap());
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,3 +1,7 @@
+use cargo_valgrind::binaries;
+
 fn main() {
-    println!("Hello, world!");
+    for binary in binaries("Cargo.toml").unwrap() {
+        println!("{}", binary.to_str().unwrap());
+    }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,7 +1,12 @@
 use cargo_valgrind::{binaries, Build};
 
 fn main() {
-    for binary in binaries("Cargo.toml", Build::Debug).unwrap() {
-        println!("{}", binary.to_str().unwrap());
+    match binaries("Cargo.toml", Build::Debug) {
+        Ok(binaries) => {
+            for binary in binaries {
+                println!("{}", binary.to_str().unwrap());
+            }
+        }
+        Err(e) => eprintln!("Error: {}", e),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,14 @@ impl AsRef<Path> for Build {
 /// are all the examples, benches as the actual crate binaries. This is based on
 /// the crate metadata obtained by [`metadata()`](fn.metadata.html).
 ///
+/// Note, that workspaces as well as plain tests currently are not supported.
+///
 /// # Errors
 /// This function fails for the same reasons as the `metadata()` function.
+///
+/// # Panics
+/// This function currently panics, if a test or custom build binary is
+/// encountered.
 pub fn binaries<P: AsRef<Path>>(path: P, build: Build) -> Result<Vec<PathBuf>, io::Error> {
     let package = metadata(path)?;
 
@@ -55,9 +61,7 @@ pub fn binaries<P: AsRef<Path>>(path: P, build: Build) -> Result<Vec<PathBuf>, i
                             | metadata::Kind::DyLib
                             | metadata::Kind::CDyLib
                             | metadata::Kind::StaticLib
-                            | metadata::Kind::RLib => {
-                                unreachable!("Non-binaries are filtered out ({})", target.name)
-                            }
+                            | metadata::Kind::RLib => unreachable!("Non-binaries are filtered out"),
                         })
                         .join(target.name)
                 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,33 @@
 //! The core library of the `cargo-valgrind` command.
 mod metadata;
+
+use std::{path::Path, io, process::Command};
+
+/// Run the `cargo metadata` command and collect its output.
+///
+/// The `path` has to point to the `Cargo.toml` of which the metadata should be
+/// collected. Metadata of the dependencies is omitted on purpose. The output is
+/// then converted into a `String`.
+///
+/// # Errors
+/// This function can fail either because the `cargo metadata` command could not
+/// be spawned, the command failed (i.e. it was executed but returned a non-zero
+/// exit code) or the string printed to stdout was not valid UTF-8.
+fn cargo_metadata<P: AsRef<Path>>(path: P) -> Result<String, io::Error> {
+    let output = Command::new("cargo")
+        .arg("metadata")
+        .arg("--format-version=1")
+        .arg("--no-deps")
+        .arg("--offline")
+        .arg("--manifest-path")
+        .arg(path.as_ref())
+        .output()?;
+
+    if output.status.success() {
+        String::from_utf8(output.stdout)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "Non-UTF-8 string"))
+    } else {
+        dbg!(String::from_utf8(output.stderr).unwrap());
+        Err(io::Error::new(io::ErrorKind::Other, "cargo command failed"))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,22 @@ use std::{
     process::Command,
 };
 
+/// The possible build types.
+pub enum Build {
+    /// This is a debug build.
+    Debug,
+    /// This is a release build.
+    Release,
+}
+impl AsRef<Path> for Build {
+    fn as_ref(&self) -> &Path {
+        match self {
+            Build::Debug => Path::new("debug"),
+            Build::Release => Path::new("release"),
+        }
+    }
+}
+
 /// Query all binaries of the crate denoted by the given `Cargo.toml`.
 ///
 /// This function returns the paths to each executable in the given crate. Those
@@ -15,10 +31,10 @@ use std::{
 ///
 /// # Errors
 /// This function fails for the same reasons as the `metadata()` function.
-pub fn binaries<P: AsRef<Path>>(path: P) -> Result<Vec<PathBuf>, io::Error> {
+pub fn binaries<P: AsRef<Path>>(path: P, build: Build) -> Result<Vec<PathBuf>, io::Error> {
     let package = metadata(path)?;
 
-    let target_dir = package.target_directory.join("debug");
+    let target_dir = package.target_directory.join(build);
     Ok(package
         .packages
         .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 //! The core library of the `cargo-valgrind` command.
 mod metadata;
+#[cfg(test)]
+mod tests;
 
 use std::{
     io,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+//! The core library of the `cargo-valgrind` command.
+mod metadata;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
 pub fn binaries<P: AsRef<Path>>(path: P) -> Result<Vec<PathBuf>, io::Error> {
     let package = metadata(path)?;
 
-    let target_dir = package.target_directory;
+    let target_dir = package.target_directory.join("debug");
     Ok(package
         .packages
         .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,23 @@
 //! The core library of the `cargo-valgrind` command.
 mod metadata;
 
-use std::{path::Path, io, process::Command};
+use std::{io, path::Path, process::Command};
+
+/// Query the crate metadata of the given `Cargo.toml`.
+///
+/// This collects the metadata of the crate denoted by the `path` using the
+/// [`cargo_metadata()`](fn.cargo_metadata.html) function. Its output is then
+/// parsed into the `Metadata` structure.
+///
+/// # Errors
+/// This function either fails because of an error of the `cargo_metadata()`
+/// function or due to an invalid output by it, that could not successfully be
+/// parsed.
+fn metadata<P: AsRef<Path>>(path: P) -> Result<metadata::Metadata, io::Error> {
+    let metadata = cargo_metadata(path)?;
+    serde_json::from_str(&metadata)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Invalid metadata: {}", e)))
+}
 
 /// Run the `cargo metadata` command and collect its output.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,23 @@ impl AsRef<Path> for Build {
 /// This function currently panics, if a test or custom build binary is
 /// encountered.
 pub fn binaries<P: AsRef<Path>>(path: P, build: Build) -> Result<Vec<PathBuf>, io::Error> {
-    let path = path.as_ref().canonicalize()?;
     let package = metadata(&path)?;
+    binaries_from(package, path, build)
+}
+
+/// Query all binaries of given metadata.
+///
+/// See [`binaries()`](fn.binaries.html) for details.
+///
+/// This is the real implementation of the `binaries()` function. It was added
+/// in order to be able to test this function without actual `Cargo.toml`s and
+/// by giving prepared metadata.
+fn binaries_from<P: AsRef<Path>>(
+    package: metadata::Metadata,
+    requested: P,
+    build: Build,
+) -> Result<Vec<PathBuf>, io::Error> {
+    let path = requested.as_ref().canonicalize()?;
 
     let is_requested = |package: &metadata::Package| {
         package

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,15 @@ pub fn binaries<P: AsRef<Path>>(path: P, build: Build) -> Result<Vec<PathBuf>, i
                             metadata::Kind::Binary => "",
                             metadata::Kind::Example => "examples",
                             metadata::Kind::Bench => "benches",
-                            metadata::Kind::Library => unreachable!(),
+                            metadata::Kind::Test | metadata::Kind::CustomBuild => unimplemented!(),
+                            metadata::Kind::Library
+                            | metadata::Kind::ProcMacro
+                            | metadata::Kind::DyLib
+                            | metadata::Kind::CDyLib
+                            | metadata::Kind::StaticLib
+                            | metadata::Kind::RLib => {
+                                unreachable!("Non-binaries are filtered out ({})", target.name)
+                            }
                         })
                         .join(target.name)
                 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,11 @@ fn cargo_metadata<P: AsRef<Path>>(path: P) -> Result<String, io::Error> {
         String::from_utf8(output.stdout)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "Non-UTF-8 string"))
     } else {
-        dbg!(String::from_utf8(output.stderr).unwrap());
-        Err(io::Error::new(io::ErrorKind::Other, "cargo command failed"))
+        let msg = String::from_utf8_lossy(&output.stderr);
+        let msg = msg.trim_start_matches("error: ").trim_end();
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("cargo command failed: {}", msg),
+        ))
     }
 }

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -38,6 +38,20 @@ pub enum Kind {
     Bench,
     #[serde(rename = "lib")]
     Library,
+    #[serde(rename = "dylib")]
+    DyLib,
+    #[serde(rename = "cdylib")]
+    CDyLib,
+    #[serde(rename = "staticlib")]
+    StaticLib,
+    #[serde(rename = "rlib")]
+    RLib,
+    #[serde(rename = "test")]
+    Test,
+    #[serde(rename = "proc-macro")]
+    ProcMacro,
+    #[serde(rename = "custom-build")]
+    CustomBuild,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
@@ -46,4 +60,14 @@ pub enum CrateType {
     Binary,
     #[serde(rename = "lib")]
     Library,
+    #[serde(rename = "dylib")]
+    DyLib,
+    #[serde(rename = "cdylib")]
+    CDyLib,
+    #[serde(rename = "staticlib")]
+    StaticLib,
+    #[serde(rename = "rlib")]
+    RLib,
+    #[serde(rename = "proc-macro")]
+    ProcMacro,
 }

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -19,6 +19,7 @@ pub struct Metadata {
 pub struct Package {
     pub id: String,
     pub targets: Vec<Target>,
+    pub manifest_path: PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -1,6 +1,7 @@
 //! A module for deserializing the cargo metadata output.
 #[cfg(test)]
 mod tests;
+mod version;
 
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -10,6 +11,7 @@ use std::path::PathBuf;
 pub struct Metadata {
     pub packages: Vec<Package>,
     pub target_directory: PathBuf,
+    #[serde(deserialize_with = "version::deserialize")]
     pub version: u32,
 }
 

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -1,0 +1,47 @@
+//! A module for deserializing the cargo metadata output.
+#[cfg(test)]
+mod tests;
+
+use serde::Deserialize;
+use std::path::PathBuf;
+
+/// The metadata of the crate to compile and run valgrind on.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+pub struct Metadata {
+    pub packages: Vec<Package>,
+    pub target_directory: PathBuf,
+    pub version: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+pub struct Package {
+    pub id: String,
+    pub targets: Vec<Target>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+pub struct Target {
+    pub kind: Vec<Kind>,
+    pub crate_types: Vec<CrateType>,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
+pub enum Kind {
+    #[serde(rename = "bin")]
+    Binary,
+    #[serde(rename = "example")]
+    Example,
+    #[serde(rename = "bench")]
+    Bench,
+    #[serde(rename = "lib")]
+    Library,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
+pub enum CrateType {
+    #[serde(rename = "bin")]
+    Binary,
+    #[serde(rename = "lib")]
+    Library,
+}

--- a/src/metadata/sample-metadata.json
+++ b/src/metadata/sample-metadata.json
@@ -1,0 +1,176 @@
+{
+    "packages": [
+        {
+            "name": "vk",
+            "version": "0.1.14",
+            "id": "vk 0.1.14 (path+file:///home/jfrimmel/git/lava.rs/vk-core)",
+            "license": null,
+            "license_file": null,
+            "description": "Low-level rusty bindings to the Vulkan API",
+            "source": null,
+            "dependencies": [
+                {
+                    "name": "log",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.4.7",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "once_cell",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.2.4",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": false,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "vk",
+                    "src_path": "/home/jfrimmel/git/lava.rs/vk-core/src/lib.rs",
+                    "edition": "2018"
+                }
+            ],
+            "features": {
+                "parking_lot": [
+                    "once_cell/parking_lot"
+                ],
+                "statically-linked": []
+            },
+            "manifest_path": "/home/jfrimmel/git/lava.rs/vk-core/Cargo.toml",
+            "metadata": null,
+            "authors": [
+                "Julian Frimmel <julian.frimmel@gmail.com>"
+            ],
+            "categories": [],
+            "keywords": [],
+            "readme": null,
+            "repository": "https://github.com/jfrimmel/lava.rs",
+            "edition": "2018",
+            "links": null
+        },
+        {
+            "name": "lava-rs",
+            "version": "0.1.4",
+            "id": "lava-rs 0.1.4 (path+file:///home/jfrimmel/git/lava.rs)",
+            "license": null,
+            "license_file": null,
+            "description": "Convenient and performant way to use the Vulkan API from Rust",
+            "source": null,
+            "dependencies": [
+                {
+                    "name": "vk",
+                    "source": null,
+                    "req": "*",
+                    "kind": null,
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                },
+                {
+                    "name": "env_logger",
+                    "source": "registry+https://github.com/rust-lang/crates.io-index",
+                    "req": "^0.6.2",
+                    "kind": "dev",
+                    "rename": null,
+                    "optional": false,
+                    "uses_default_features": true,
+                    "features": [],
+                    "target": null,
+                    "registry": null
+                }
+            ],
+            "targets": [
+                {
+                    "kind": [
+                        "lib"
+                    ],
+                    "crate_types": [
+                        "lib"
+                    ],
+                    "name": "lava-rs",
+                    "src_path": "/home/jfrimmel/git/lava.rs/src/lib.rs",
+                    "edition": "2018"
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "creation",
+                    "src_path": "/home/jfrimmel/git/lava.rs/examples/creation.rs",
+                    "edition": "2018"
+                },
+                {
+                    "kind": [
+                        "example"
+                    ],
+                    "crate_types": [
+                        "bin"
+                    ],
+                    "name": "version",
+                    "src_path": "/home/jfrimmel/git/lava.rs/examples/version.rs",
+                    "edition": "2018"
+                }
+            ],
+            "features": {
+                "parking_lot": [
+                    "vk/parking_lot"
+                ],
+                "statically-linked": [
+                    "vk/statically-linked"
+                ]
+            },
+            "manifest_path": "/home/jfrimmel/git/lava.rs/Cargo.toml",
+            "metadata": null,
+            "authors": [
+                "Julian Frimmel <julian.frimmel@gmail.com>"
+            ],
+            "categories": [
+                "api-bindings",
+                "graphics",
+                "game-engines"
+            ],
+            "keywords": [
+                "api",
+                "ffi",
+                "graphics",
+                "vulkan",
+                "game-development"
+            ],
+            "readme": "README.md",
+            "repository": "https://github.com/jfrimmel/lava.rs",
+            "edition": "2018",
+            "links": null
+        }
+    ],
+    "workspace_members": [
+        "vk 0.1.14 (path+file:///home/jfrimmel/git/lava.rs/vk-core)",
+        "lava-rs 0.1.4 (path+file:///home/jfrimmel/git/lava.rs)"
+    ],
+    "resolve": null,
+    "target_directory": "/home/jfrimmel/git/lava.rs/target",
+    "version": 1,
+    "workspace_root": "/home/jfrimmel/git/lava.rs"
+}

--- a/src/metadata/tests.rs
+++ b/src/metadata/tests.rs
@@ -1,0 +1,7 @@
+use super::Metadata;
+
+#[test]
+fn sample_metadata_can_be_deserialized() {
+    let file = std::fs::File::open("src/metadata/sample-metadata.json").unwrap();
+    let _metadata: Metadata = serde_json::from_reader(file).unwrap();
+}

--- a/src/metadata/tests.rs
+++ b/src/metadata/tests.rs
@@ -5,3 +5,17 @@ fn sample_metadata_can_be_deserialized() {
     let file = std::fs::File::open("src/metadata/sample-metadata.json").unwrap();
     let _metadata: Metadata = serde_json::from_reader(file).unwrap();
 }
+
+#[test]
+fn only_version_1_is_supported() {
+    let result: Result<Metadata, _> = serde_json::from_str(
+        r#"
+{
+    "version": 1,
+    "packages": []
+    "target_directory": ""
+}
+    "#,
+    );
+    result.unwrap_err();
+}

--- a/src/metadata/version.rs
+++ b/src/metadata/version.rs
@@ -1,0 +1,49 @@
+//! Deserializer for the `version` field of the metadata.
+//!
+//! This checks, that the metadata is indeed the version `1`, since any other
+//! version cannot be reliably be parsed.
+use serde::de::{Deserializer, Error, Visitor};
+use std::fmt::{self, Formatter};
+
+/// Deserialize the `version` field of the cargo metadata.
+///
+/// The only supported version is version 1, so any other value will fail to
+/// deserialize.
+pub fn deserialize<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_u32(VersionVisitor)
+}
+
+/// A macro for reducing the boilerplate of checking for `"1"` for each type.
+macro_rules! visit_integer {
+    ($function:ident, $type:ty) => {
+        fn $function<E: Error>(self, value: $type) -> Result<Self::Value, E> {
+            if value == 1 {
+                Ok(value as _)
+            } else {
+                Err(E::custom("only version 1 is supported"))
+            }
+        }
+    };
+}
+
+/// A visitor for the version field.
+struct VersionVisitor;
+impl<'de> Visitor<'de> for VersionVisitor {
+    type Value = u32;
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        formatter.write_str("1")
+    }
+
+    visit_integer!(visit_i8, i8);
+    visit_integer!(visit_u8, u8);
+    visit_integer!(visit_i16, i16);
+    visit_integer!(visit_u16, u16);
+    visit_integer!(visit_i32, i32);
+    visit_integer!(visit_u32, u32);
+    visit_integer!(visit_i64, i64);
+    visit_integer!(visit_u64, u64);
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,191 @@
+use super::{
+    binaries_from,
+    metadata::{CrateType, Kind, Metadata, Package, Target},
+    Build,
+};
+use std::path::PathBuf;
+
+#[test]
+fn multiple_binaries_are_supported() {
+    let manifest = PathBuf::from("a/test/Cargo.toml");
+    let metadata = Metadata {
+        target_directory: "test-dir".into(),
+        version: 1,
+        packages: vec![Package {
+            id: "a test crate".into(),
+            manifest_path: manifest.clone(),
+            targets: vec![
+                Target {
+                    crate_types: vec![CrateType::Binary],
+                    kind: vec![Kind::Binary],
+                    name: "a binary".into(),
+                },
+                Target {
+                    crate_types: vec![CrateType::Binary],
+                    kind: vec![Kind::Binary],
+                    name: "another binary".into(),
+                },
+            ],
+        }],
+    };
+    assert_eq!(
+        binaries_from(metadata, manifest, Build::Debug).unwrap(),
+        vec![
+            PathBuf::from("test-dir/debug/a binary"),
+            PathBuf::from("test-dir/debug/another binary"),
+        ]
+    );
+}
+
+#[test]
+fn examples_are_supported() {
+    let manifest = PathBuf::from("a/test/Cargo.toml");
+    let metadata = Metadata {
+        target_directory: "test-dir".into(),
+        version: 1,
+        packages: vec![Package {
+            id: "a test crate".into(),
+            manifest_path: manifest.clone(),
+            targets: vec![Target {
+                crate_types: vec![CrateType::Binary],
+                kind: vec![Kind::Example],
+                name: "an example".into(),
+            }],
+        }],
+    };
+    assert_eq!(
+        binaries_from(metadata, manifest, Build::Debug).unwrap(),
+        vec![PathBuf::from("test-dir/debug/examples/an example")]
+    );
+}
+
+#[test]
+fn benches_are_supported() {
+    let manifest = PathBuf::from("a/test/Cargo.toml");
+    let metadata = Metadata {
+        target_directory: "test-dir".into(),
+        version: 1,
+        packages: vec![Package {
+            id: "a test crate".into(),
+            manifest_path: manifest.clone(),
+            targets: vec![Target {
+                crate_types: vec![CrateType::Binary],
+                kind: vec![Kind::Bench],
+                name: "a benchmark".into(),
+            }],
+        }],
+    };
+    assert_eq!(
+        binaries_from(metadata, manifest, Build::Debug).unwrap(),
+        vec![PathBuf::from("test-dir/debug/benches/a benchmark")]
+    );
+}
+
+#[test]
+fn libraries_are_ignored() {
+    let manifest = PathBuf::from("a/test/Cargo.toml");
+    let metadata = Metadata {
+        target_directory: "test-dir".into(),
+        version: 1,
+        packages: vec![Package {
+            id: "a test crate".into(),
+            manifest_path: manifest.clone(),
+            targets: vec![
+                Target {
+                    crate_types: vec![CrateType::Library],
+                    kind: vec![Kind::Library],
+                    name: "a lib".into(),
+                },
+                Target {
+                    crate_types: vec![CrateType::DyLib],
+                    kind: vec![Kind::DyLib],
+                    name: "a dylib".into(),
+                },
+                Target {
+                    crate_types: vec![CrateType::CDyLib],
+                    kind: vec![Kind::CDyLib],
+                    name: "a cdylib".into(),
+                },
+                Target {
+                    crate_types: vec![CrateType::StaticLib],
+                    kind: vec![Kind::StaticLib],
+                    name: "a static lib".into(),
+                },
+                Target {
+                    crate_types: vec![CrateType::RLib],
+                    kind: vec![Kind::RLib],
+                    name: "an rlib".into(),
+                },
+            ],
+        }],
+    };
+    assert_eq!(
+        binaries_from(metadata, manifest, Build::Debug).unwrap(),
+        Vec::<PathBuf>::new()
+    );
+}
+
+#[test]
+fn proc_macros_are_ignored() {
+    let manifest = PathBuf::from("a/test/Cargo.toml");
+    let metadata = Metadata {
+        target_directory: "test-dir".into(),
+        version: 1,
+        packages: vec![Package {
+            id: "a test crate".into(),
+            manifest_path: manifest.clone(),
+            targets: vec![Target {
+                crate_types: vec![CrateType::ProcMacro],
+                kind: vec![Kind::ProcMacro],
+                name: "a proc macro".into(),
+            }],
+        }],
+    };
+    assert_eq!(
+        binaries_from(metadata, manifest, Build::Debug).unwrap(),
+        Vec::<PathBuf>::new()
+    );
+}
+
+#[test]
+fn only_binaries_of_manifest_are_returned() {
+    let manifest = PathBuf::from("a/test/Cargo.toml");
+    let metadata = Metadata {
+        target_directory: "test-dir".into(),
+        version: 1,
+        packages: vec![
+            Package {
+                id: "a test crate".into(),
+                manifest_path: manifest.clone(),
+                targets: vec![
+                    Target {
+                        crate_types: vec![CrateType::Binary],
+                        kind: vec![Kind::Binary],
+                        name: "a binary".into(),
+                    },
+                    Target {
+                        crate_types: vec![CrateType::Binary],
+                        kind: vec![Kind::Binary],
+                        name: "another binary".into(),
+                    },
+                ],
+            },
+            Package {
+                id: "another crate of the workspace".into(),
+                manifest_path: manifest.clone().join("sub-crate"),
+                targets: vec![Target {
+                    crate_types: vec![CrateType::Binary],
+                    kind: vec![Kind::Binary],
+                    name: "wrong binary".into(),
+                }],
+            },
+        ],
+    };
+    assert_eq!(
+        binaries_from(metadata, manifest, Build::Debug).unwrap(),
+        vec![
+            PathBuf::from("test-dir/debug/a binary"),
+            PathBuf::from("test-dir/debug/another binary"),
+        ]
+    );
+}


### PR DESCRIPTION
This PR adds some functions, that can be used to get the paths of all executables of a crate. The crate itself is located by the path to the `Cargo.toml` file.
Note, that currently tests are not supported. Furthermore, workspaces are not supported as well; only the binaries of the specified manifest are returned.