### PR TITLE
Added method to build the target executable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "cargo-valgrind"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-valgrind"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Julian Frimmel <julian.frimmel@gmail.com>"]
 edition = "2018"
 description = "A cargo subcommand for running valgrind"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod metadata;
 mod tests;
 
 use std::{
+    ffi::OsString,
     io,
     path::{Path, PathBuf},
     process::{Command, Output},
@@ -35,13 +36,13 @@ impl AsRef<Path> for Build {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Target {
     /// A normal binary with the given name.
-    Binary(String),
+    Binary(OsString),
     /// An example with the given name.
-    Example(String),
+    Example(OsString),
     /// A benchmark with the given name.
-    Benchmark(String),
+    Benchmark(OsString),
     /// A test with the given name.
-    Test(String),
+    Test(OsString),
 }
 
 /// Invoke `cargo` and build the specified target.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,19 @@ impl AsRef<Path> for Build {
     }
 }
 
+/// The possible targets to build and run within valgrind.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Target {
+    /// A normal binary with the given name.
+    Binary(String),
+    /// An example with the given name.
+    Example(String),
+    /// A benchmark with the given name.
+    Benchmark(String),
+    /// A test with the given name.
+    Test(String),
+}
+
 /// Query all binaries of the crate denoted by the given `Cargo.toml`.
 ///
 /// This function returns the paths to each executable in the given crate. Those


### PR DESCRIPTION
The new function runs cargo and builds the executable. After a call to it the artifact is in place and can be run with valgrind.