### PR TITLE
Provide target kinds along their paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-valgrind"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-valgrind"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Julian Frimmel <julian.frimmel@gmail.com>"]
 edition = "2018"
 description = "A cargo subcommand for running valgrind"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,6 +275,30 @@ pub fn binaries<P: AsRef<Path>>(path: P, build: Build) -> Result<Vec<PathBuf>, E
         .collect())
 }
 
+/// Query all targets of the crate denoted by the given `Cargo.toml`.
+///
+/// This function returns the paths to and type of each executable in the given
+/// crate. Those are all the examples, benches as the actual crate binaries.
+/// This is based on the crate metadata obtained by
+/// [`metadata()`](fn.metadata.html).
+///
+/// Only binaries of the specified manifest are returned. This means, that other
+/// crates in the same workspace may have binaries, but they are ignored.
+///
+/// Note, that plain tests and `custom-build` kinds currently are not supported.
+///
+/// # Errors
+/// This function fails for the same reasons as the `metadata()` function.
+///
+/// # Panics
+/// This function currently panics, if a test or custom build binary is
+/// encountered.
+pub fn targets<P: AsRef<Path>>(path: P, build: Build) -> Result<Vec<Target>, Error> {
+    let package = metadata(&path)?;
+    let path = path.as_ref().canonicalize()?;
+    binaries_from(package, path, build)
+}
+
 /// Query all binaries of given metadata.
 ///
 /// See [`binaries()`](fn.binaries.html) for details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,7 @@ fn run_in_valgrind<P: AsRef<Path>>(path: P) -> Result<valgrind_xml::Output, Erro
 /// # Panics
 /// This function currently panics, if a test or custom build binary is
 /// encountered.
+#[deprecated(note = "use targets() instead, as it provides more information")]
 pub fn binaries<P: AsRef<Path>>(path: P, build: Build) -> Result<Vec<PathBuf>, Error> {
     let package = metadata(&path)?;
     let path = path.as_ref().canonicalize()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ mod tests;
 mod valgrind_xml;
 
 use std::{
-    ffi::OsString,
     fmt::{self, Display, Formatter},
     io::{Error, ErrorKind},
     net::{SocketAddr, TcpListener},
@@ -40,13 +39,13 @@ impl AsRef<Path> for Build {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Target {
     /// A normal binary with the given name.
-    Binary(OsString),
+    Binary(PathBuf),
     /// An example with the given name.
-    Example(OsString),
+    Example(PathBuf),
     /// A benchmark with the given name.
-    Benchmark(OsString),
+    Benchmark(PathBuf),
     /// A test with the given name.
-    Test(OsString),
+    Test(PathBuf),
 }
 
 /// Invoke `cargo` and build the specified target.


### PR DESCRIPTION
Previously, the `binary()` function returned only the path to the different binaries of the crate. The information, which kind of binary (binary, example, benchmark, test) it is, is lost.
The new `target()` function provides this additional information. The old function is kept for compatibility, but is deprecated in favor of the new one.