### PR TITLE
Support all binary targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-valgrind"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-valgrind"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-valgrind"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Julian Frimmel <julian.frimmel@gmail.com>"]
 edition = "2018"
 description = "A cargo subcommand for running valgrind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-valgrind"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Julian Frimmel <julian.frimmel@gmail.com>"]
 edition = "2018"
 description = "A cargo subcommand for running valgrind"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -99,6 +99,17 @@ fn specified_target(parameters: &ArgMatches) -> Option<Target> {
             .map(|path| Target::Benchmark(PathBuf::from(path))))
 }
 
+/// Search for the actual binary to analyze.
+///
+/// This function takes the output of `specified_target()`, as well as the list
+/// of all possible targets returned by `targets()`. It searches, if the
+/// requested binary exists. If no binary was specified and there is only one
+/// target available, that target is used.
+///
+/// # Errors
+/// This function returns an error, if there is no target specified and there
+/// are multiple targets to choose from, or if the user specified a non-existing
+/// target.
 fn find_target(specified: Option<Target>, targets: &[Target]) -> Result<Target> {
     let target = match specified {
         Some(path) => path,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,4 @@
-use cargo_valgrind::{targets, build_target, valgrind, Build, Target};
+use cargo_valgrind::{build_target, targets, valgrind, Build, Target};
 use clap::{crate_authors, crate_name, crate_version, App, Arg};
 use colored::Colorize;
 use std::path::PathBuf;
@@ -61,10 +61,12 @@ fn run() -> Result<bool, Box<dyn std::error::Error>> {
     let binary = cli
         .value_of("bin")
         .map(|path| Target::Binary(PathBuf::from(path)))
-        .or(cli.value_of("example")
-        .map(|path| Target::Example(PathBuf::from(path))))
-        .or(cli.value_of("bench")
-        .map(|path| Target::Benchmark(PathBuf::from(path))));
+        .or(cli
+            .value_of("example")
+            .map(|path| Target::Example(PathBuf::from(path))))
+        .or(cli
+            .value_of("bench")
+            .map(|path| Target::Benchmark(PathBuf::from(path))));
     let manifest = cli.value_of("manifest").unwrap_or("Cargo.toml".into());
     let manifest = PathBuf::from(manifest).canonicalize()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,12 +130,7 @@ pub fn build_target<P: AsRef<Path>>(
         Target::Benchmark(_) => cmd.arg("--bench"),
         Target::Test(_) => cmd.arg("--test"),
     };
-    match target {
-        Target::Binary(name)
-        | Target::Example(name)
-        | Target::Benchmark(name)
-        | Target::Test(name) => cmd.arg(name),
-    };
+    cmd.arg(target.name());
     cmd.spawn()?.wait_with_output().and_then(|output| {
         if output.status.success() {
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,62 @@ pub enum Target {
     /// A test with the given name.
     Test(PathBuf),
 }
+impl Target {
+    /// Query the path to the target binary.
+    pub fn path(&self) -> &Path {
+        match self {
+            Target::Binary(path)
+            | Target::Example(path)
+            | Target::Benchmark(path)
+            | Target::Test(path) => path.as_path(),
+        }
+    }
+
+    /// Query the name of the target binary.
+    ///
+    /// # Panics
+    /// This method panics, if either the path has no file name, i.e. it is
+    /// empty or the file name contains invalid UTF-8.
+    pub fn name(&self) -> &str {
+        self.path()
+            .file_name()
+            .expect("binary has no name")
+            .to_str()
+            .expect("binary name contained invalid UTF-8")
+    }
+
+    /// Query, if the target is an ordinary binary.
+    pub fn is_binary(&self) -> bool {
+        match self {
+            Target::Binary(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Query, if the target is an example binary.
+    pub fn is_example(&self) -> bool {
+        match self {
+            Target::Example(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Query, if the target is a benchmark binary.
+    pub fn is_benchmark(&self) -> bool {
+        match self {
+            Target::Benchmark(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Query, if the target is a test binary.
+    pub fn is_test(&self) -> bool {
+        match self {
+            Target::Test(_) => true,
+            _ => false,
+        }
+    }
+}
 
 /// Invoke `cargo` and build the specified target.
 ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,8 +31,8 @@ fn multiple_binaries_are_supported() {
     assert_eq!(
         binaries_from(metadata, manifest, Build::Debug).unwrap(),
         vec![
-            PathBuf::from("test-dir/debug/a binary"),
-            PathBuf::from("test-dir/debug/another binary"),
+            crate::Target::Binary(PathBuf::from("test-dir/debug/a binary")),
+            crate::Target::Binary(PathBuf::from("test-dir/debug/another binary")),
         ]
     );
 }
@@ -55,7 +55,9 @@ fn examples_are_supported() {
     };
     assert_eq!(
         binaries_from(metadata, manifest, Build::Debug).unwrap(),
-        vec![PathBuf::from("test-dir/debug/examples/an example")]
+        vec![crate::Target::Example(PathBuf::from(
+            "test-dir/debug/examples/an example"
+        ))]
     );
 }
 
@@ -77,7 +79,9 @@ fn benches_are_supported() {
     };
     assert_eq!(
         binaries_from(metadata, manifest, Build::Debug).unwrap(),
-        vec![PathBuf::from("test-dir/debug/benches/a benchmark")]
+        vec![crate::Target::Benchmark(PathBuf::from(
+            "test-dir/debug/benches/a benchmark"
+        ))]
     );
 }
 
@@ -121,7 +125,7 @@ fn libraries_are_ignored() {
     };
     assert_eq!(
         binaries_from(metadata, manifest, Build::Debug).unwrap(),
-        Vec::<PathBuf>::new()
+        Vec::<_>::new()
     );
 }
 
@@ -143,7 +147,7 @@ fn proc_macros_are_ignored() {
     };
     assert_eq!(
         binaries_from(metadata, manifest, Build::Debug).unwrap(),
-        Vec::<PathBuf>::new()
+        Vec::<_>::new()
     );
 }
 
@@ -184,8 +188,8 @@ fn only_binaries_of_manifest_are_returned() {
     assert_eq!(
         binaries_from(metadata, manifest, Build::Debug).unwrap(),
         vec![
-            PathBuf::from("test-dir/debug/a binary"),
-            PathBuf::from("test-dir/debug/another binary"),
+            crate::Target::Binary(PathBuf::from("test-dir/debug/a binary")),
+            crate::Target::Binary(PathBuf::from("test-dir/debug/another binary")),
         ]
     );
 }

--- a/src/valgrind_xml/tests.rs
+++ b/src/valgrind_xml/tests.rs
@@ -5,18 +5,19 @@ fn sample_output() {
     let xml: Output =
         serde_xml_rs::from_reader(std::fs::File::open("src/valgrind_xml/vg.xml").unwrap()).unwrap();
 
-    assert_eq!(xml.errors.len(), 8);
-    assert_eq!(xml.errors[0].kind, Kind::LeakDefinitelyLost);
-    assert_eq!(xml.errors[0].unique, 0x0);
+    let errors = xml.errors.unwrap();
+    assert_eq!(errors.len(), 8);
+    assert_eq!(errors[0].kind, Kind::LeakDefinitelyLost);
+    assert_eq!(errors[0].unique, 0x0);
     assert_eq!(
-        xml.errors[0].resources,
+        errors[0].resources,
         Resources {
             bytes: 15,
             blocks: 1,
         }
     );
     assert_eq!(
-        &xml.errors[0].stack_trace.frames[..2],
+        &errors[0].stack_trace.frames[..2],
         &[
             Frame {
                 instruction_pointer: 0x483AD7B,
@@ -39,10 +40,10 @@ fn sample_output() {
         ]
     );
 
-    assert_eq!(xml.errors[1].kind, Kind::LeakStillReachable);
-    assert_eq!(xml.errors[1].unique, 0x1);
+    assert_eq!(errors[1].kind, Kind::LeakStillReachable);
+    assert_eq!(errors[1].unique, 0x1);
     assert_eq!(
-        xml.errors[1].resources,
+        errors[1].resources,
         Resources {
             bytes: 24,
             blocks: 1,


### PR DESCRIPTION
This PR enables the support for running examples and benchmarks using `cargo-valgrind`.
The main application code (in `main.rs`) has undergone a massive refactoring.