### PR TITLE
Fixed target comparison.

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -118,7 +118,7 @@ fn find_target(specified: Option<Target>, targets: &[Target]) -> Result<Target> 
     };
     let target = targets
         .into_iter()
-        .find(|path| path.name() == target.name())
+        .find(|&path| path == &target)
         .cloned()
         .ok_or("Could not find selected binary")?;
     Ok(target)


### PR DESCRIPTION
Previously it was possible to specify `--example cstring` and if a bin-
ary (not an example) with that name exists, it was used.
This commit changes the behavior to the expected one.