### PR TITLE
Better error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-valgrind"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-valgrind"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Julian Frimmel <julian.frimmel@gmail.com>"]
 edition = "2018"
 description = "A cargo subcommand for running valgrind"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -116,6 +116,19 @@ fn specified_target(parameters: &ArgMatches) -> Option<Target> {
 /// are multiple targets to choose from, or if the user specified a non-existing
 /// target.
 fn find_target(specified: Option<Target>, targets: &[Target]) -> Result<Target> {
+    let target_type = |target: &Target| {
+        if target.is_binary() {
+            "bin"
+        } else if target.is_example() {
+            "example"
+        } else if target.is_benchmark() {
+            "bench"
+        } else if target.is_test() {
+            "test"
+        } else {
+            unreachable!();
+        }
+    };
     let target = match specified {
         Some(path) => path,
         None if targets.len() == 1 => targets[0].clone(),
@@ -124,17 +137,7 @@ fn find_target(specified: Option<Target>, targets: &[Target]) -> Result<Target> 
             let targets: Vec<_> = targets
                 .iter()
                 .map(|target| {
-                    let flag = if target.is_binary() {
-                        "bin"
-                    } else if target.is_example() {
-                        "example"
-                    } else if target.is_benchmark() {
-                        "bench"
-                    } else if target.is_test() {
-                        "test"
-                    } else {
-                        unreachable!();
-                    };
+                    let flag = target_type(target);
                     format!("--{} {}", flag, target.name())
                 })
                 .collect();
@@ -147,7 +150,11 @@ fn find_target(specified: Option<Target>, targets: &[Target]) -> Result<Target> 
         .into_iter()
         .find(|&path| path == &target)
         .cloned()
-        .ok_or("Could not find selected binary")?;
+        .ok_or(format!(
+            "Could not find {} target `{}`",
+            target_type(&target).replace("bin", "binary"),
+            target.name()
+        ))?;
     Ok(target)
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -119,7 +119,24 @@ fn find_target(specified: Option<Target>, targets: &[Target]) -> Result<Target> 
     let target = match specified {
         Some(path) => path,
         None if targets.len() == 1 => targets[0].clone(),
-        None => Err("Multiple possible targets, please specify more precise")?,
+        None => {
+            let mut error = String::from("Multiple possible targets, please specify one of:\n");
+            for target in targets {
+                let flag = if target.is_binary() {
+                    "bin"
+                } else if target.is_example() {
+                    "example"
+                } else if target.is_benchmark() {
+                    "bench"
+                } else if target.is_test() {
+                    "test"
+                } else {
+                    unreachable!();
+                };
+                error += &format!("--{} {}\n", flag, target.name());
+            }
+            Err(error)?
+        }
     };
     let target = targets
         .into_iter()

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -121,20 +121,25 @@ fn find_target(specified: Option<Target>, targets: &[Target]) -> Result<Target> 
         None if targets.len() == 1 => targets[0].clone(),
         None => {
             let mut error = String::from("Multiple possible targets, please specify one of:\n");
-            for target in targets {
-                let flag = if target.is_binary() {
-                    "bin"
-                } else if target.is_example() {
-                    "example"
-                } else if target.is_benchmark() {
-                    "bench"
-                } else if target.is_test() {
-                    "test"
-                } else {
-                    unreachable!();
-                };
-                error += &format!("--{} {}\n", flag, target.name());
-            }
+            let targets: Vec<_> = targets
+                .iter()
+                .map(|target| {
+                    let flag = if target.is_binary() {
+                        "bin"
+                    } else if target.is_example() {
+                        "example"
+                    } else if target.is_benchmark() {
+                        "bench"
+                    } else if target.is_test() {
+                        "test"
+                    } else {
+                        unreachable!();
+                    };
+                    format!("--{} {}", flag, target.name())
+                })
+                .collect();
+
+            error += &targets.join("\n");
             Err(error)?
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub fn build_target<P: AsRef<Path>>(
     if let Build::Release = build {
         cmd.arg("--release");
     }
-    cmd.arg("--manifest-path");
+    cmd.arg("--manifest-paths");
     cmd.arg(manifest.as_ref());
     match target {
         Target::Binary(_) => cmd.arg("--bin"),
@@ -462,5 +462,9 @@ fn cargo_metadata<P: AsRef<Path>>(path: P) -> Result<String, Error> {
 fn cargo_error(output: Output) -> Error {
     let msg = String::from_utf8_lossy(&output.stderr);
     let msg = msg.trim_start_matches("error: ").trim_end();
-    Error::new(ErrorKind::Other, format!("cargo command failed: {}", msg))
+    if msg.is_empty() {
+        Error::new(ErrorKind::Other, "cargo command failed")
+    } else {
+        Error::new(ErrorKind::Other, format!("cargo command failed: {}", msg))
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub fn build_target<P: AsRef<Path>>(
     if let Build::Release = build {
         cmd.arg("--release");
     }
-    cmd.arg("--manifest-paths");
+    cmd.arg("--manifest-path");
     cmd.arg(manifest.as_ref());
     match target {
         Target::Binary(_) => cmd.arg("--bin"),


### PR DESCRIPTION
Provide better user feedback, if the program is used wrong or the `valgrind` command could not be executed.