### PR TITLE
Added --features flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Version 1.1.0
+- Added `--features` flag.
+  This flag is the `cargo valgrind` analog to the same flag on other `cargo` subcommands.
+- deprecated `cargo_valgrind::build_target()` in favor of the more flexible `cargo_valgrind::Cargo` type.
+
+## Version 1.0.0
+- Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-valgrind"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-valgrind"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Julian Frimmel <julian.frimmel@gmail.com>"]
 edition = "2018"
 description = "A cargo subcommand for running valgrind"
@@ -17,6 +17,9 @@ keywords = [
 categories = [
     "development-tools",
     "development-tools::cargo-plugins",
+]
+exclude = [
+    "CHANGELOG.md",
 ]
 
 [[bin]]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,4 @@
-use cargo_valgrind::{build_target, targets, valgrind, Build, Leak, Target};
+use cargo_valgrind::{targets, valgrind, Build, Cargo, Leak, Target};
 use clap::{crate_authors, crate_version, App, AppSettings, Arg, ArgMatches, SubCommand};
 use colored::Colorize;
 use std::path::{Path, PathBuf};
@@ -199,7 +199,11 @@ fn run() -> Result<Report> {
 
     let targets = targets(&manifest, build)?;
     let target = find_target(target, &targets)?;
-    build_target(&manifest, build, target.clone())?;
+    Cargo::new()
+        .with_manifest(&manifest)
+        .with_build_target(target.clone())
+        .with_build_type(build)
+        .build()?;
     analyze_target(&target, &manifest)
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -217,10 +217,10 @@ fn run() -> Result<Report> {
     let targets = targets(&manifest, build)?;
     let target = find_target(target, &targets)?;
     Cargo::new()
-        .with_manifest(&manifest)
-        .with_build_target(target.clone())
-        .with_build_type(build)
-        .with_features(features)
+        .manifest(&manifest)
+        .build_target(target.clone())
+        .build_type(build)
+        .features(features)
         .build()?;
     analyze_target(&target, &manifest)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ impl std::cmp::PartialEq for Target {
 ///
 /// # Errors
 /// This function returns an error, if the `cargo command returned an error`.
+#[deprecated(note = "Use the more flexible `Cargo` type instead")]
 pub fn build_target<P: AsRef<Path>>(
     manifest: P,
     build: Build,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,7 @@ pub mod cargo_config {
     use super::{Build, Cargo, Target};
     use std::path::{Path, PathBuf};
 
+    /// A `Cargo` instance while configuring its manifest path.
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct Manifest(());
     impl Manifest {
@@ -247,17 +248,20 @@ pub mod cargo_config {
             Self(())
         }
 
+        /// Specify the path to the `Cargo.toml` to use.
         pub fn manifest<P: AsRef<Path>>(self, manifest: P) -> BuildTarget {
             let manifest = manifest.as_ref().into();
             BuildTarget { manifest }
         }
     }
 
+    /// A `Cargo` instance while configuring the target binary.
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct BuildTarget {
         manifest: PathBuf,
     }
     impl BuildTarget {
+        /// Select the build target.
         pub fn build_target(self, target: Target) -> BuildType {
             BuildType {
                 manifest: self.manifest,
@@ -266,12 +270,14 @@ pub mod cargo_config {
         }
     }
 
+    /// A `Cargo` instance while configuring the target build type.
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct BuildType {
         manifest: PathBuf,
         target: Target,
     }
     impl BuildType {
+        /// Select the build type.
         pub fn build_type(self, build: Build) -> Cargo {
             Cargo {
                 manifest: self.manifest,
@@ -281,10 +287,12 @@ pub mod cargo_config {
             }
         }
 
+        /// Make a debug build.
         pub fn debug_build(self) -> Cargo {
             self.build_type(Build::Debug)
         }
 
+        /// Make a release build.
         pub fn release_build(self) -> Cargo {
             self.build_type(Build::Release)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,15 +215,15 @@ impl Cargo {
     ///
     /// This function can be called multiple times to build with multiple
     /// features enabled.
-    pub fn with_feature<S: Into<String>>(self, feature: S) -> Self {
-        self.with_features(Some(feature))
+    pub fn feature<S: Into<String>>(self, feature: S) -> Self {
+        self.features(Some(feature))
     }
 
     /// Build the target with specific features enabled.
     ///
     /// This function can be called multiple times and mixed with the
-    /// `with_feature()` method.
-    pub fn with_features<S, I>(mut self, features: I) -> Self
+    /// `feature()` method.
+    pub fn features<S, I>(mut self, features: I) -> Self
     where
         S: Into<String>,
         I: IntoIterator<Item = S>,
@@ -246,7 +246,7 @@ pub mod cargo_config {
             Self(())
         }
 
-        pub fn with_manifest<P: AsRef<Path>>(self, manifest: P) -> BuildTarget {
+        pub fn manifest<P: AsRef<Path>>(self, manifest: P) -> BuildTarget {
             let manifest = manifest.as_ref().into();
             BuildTarget { manifest }
         }
@@ -257,7 +257,7 @@ pub mod cargo_config {
         manifest: PathBuf,
     }
     impl BuildTarget {
-        pub fn with_build_target(self, target: Target) -> BuildType {
+        pub fn build_target(self, target: Target) -> BuildType {
             BuildType {
                 manifest: self.manifest,
                 target,
@@ -271,7 +271,7 @@ pub mod cargo_config {
         target: Target,
     }
     impl BuildType {
-        pub fn with_build_type(self, build: Build) -> Cargo {
+        pub fn build_type(self, build: Build) -> Cargo {
             Cargo {
                 manifest: self.manifest,
                 target: self.target,
@@ -280,12 +280,12 @@ pub mod cargo_config {
             }
         }
 
-        pub fn as_debug_build(self) -> Cargo {
-            self.with_build_type(Build::Debug)
+        pub fn debug_build(self) -> Cargo {
+            self.build_type(Build::Debug)
         }
 
-        pub fn as_release_build(self) -> Cargo {
-            self.with_build_type(Build::Release)
+        pub fn release_build(self) -> Cargo {
+            self.build_type(Build::Release)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ impl std::cmp::PartialEq for Target {
 ///
 /// # Errors
 /// This function returns an error, if the `cargo command returned an error`.
-#[deprecated(note = "Use the more flexible `Cargo` type instead")]
+#[deprecated(since = "1.1.0", note = "Use the more flexible `Cargo` type instead")]
 pub fn build_target<P: AsRef<Path>>(
     manifest: P,
     build: Build,


### PR DESCRIPTION
This PR adds the `--features` flag to `cargo valgrind`. It can be used in the same way as the normal `cargo build` flag and builds the target with exactly those flags (and the default flags) enabled.
Note that there is no `--no-default-features` flags implemented (yet).