### PR TITLE
Print a summary of the leaked bytes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-valgrind"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-valgrind"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Julian Frimmel <julian.frimmel@gmail.com>"]
 edition = "2018"
 description = "A cargo subcommand for running valgrind"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -201,7 +201,14 @@ fn analyze_target(target: &Target, manifest: &Path) -> Result<Report> {
     if errors.is_empty() {
         Ok(Report::NoErrorDetected)
     } else {
+        let sum: usize = errors.iter().map(|leak| leak.leaked_bytes()).sum();
         errors.into_iter().for_each(display_error);
+        println!(
+            "{:>12} Leaked {} total",
+            "Summary".red().bold(),
+            bytesize::to_string(sum as _, true)
+        );
+
         Ok(Report::ContainsErrors)
     }
 }


### PR DESCRIPTION
The last line of the output in the error cases is now the total number of bytes leaked.