### PR TITLE
Make valgrind usage more extensible and future-proof

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,4 @@
-use cargo_valgrind::{targets, valgrind, Build, Cargo, Leak, Target};
+use cargo_valgrind::{targets, Valgrind, Build, Cargo, Leak, Target};
 use clap::{crate_authors, crate_version, App, AppSettings, Arg, ArgMatches, SubCommand};
 use colored::Colorize;
 use std::path::{Path, PathBuf};
@@ -201,7 +201,7 @@ fn analyze_target(target: &Target, manifest: &Path) -> Result<Report> {
         .unwrap_or_default();
     println!("{:>12} `{}`", "Analyzing".green().bold(), target_path);
 
-    let errors = valgrind(target.path())?;
+    let errors = Valgrind::new().analyze(target.path())?;
     if errors.is_empty() {
         Ok(Report::NoErrorDetected)
     } else {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,4 @@
-use cargo_valgrind::{targets, Valgrind, Build, Cargo, Leak, Target};
+use cargo_valgrind::{targets, Build, Cargo, Leak, Target, Valgrind};
 use clap::{crate_authors, crate_version, App, AppSettings, Arg, ArgMatches, SubCommand};
 use colored::Colorize;
 use std::path::{Path, PathBuf};
@@ -201,7 +201,8 @@ fn analyze_target(target: &Target, manifest: &Path) -> Result<Report> {
         .unwrap_or_default();
     println!("{:>12} `{}`", "Analyzing".green().bold(), target_path);
 
-    let errors = Valgrind::new().analyze(target.path())?;
+    let valgrind = Valgrind::new();
+    let errors = valgrind.analyze(target.path())?;
     if errors.is_empty() {
         Ok(Report::NoErrorDetected)
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,25 +316,90 @@ pub mod cargo_config {
 /// successfully, its output could not be parsed correctly or any other process
 /// related error occurs.
 pub fn valgrind<P: AsRef<Path>>(path: P) -> Result<Vec<Leak>, Error> {
-    Ok(run_in_valgrind(path)?
-        .errors
-        .unwrap_or_default()
-        .into_iter()
-        .map(|error| Leak {
-            bytes: error.resources.bytes,
-            kind: error.kind,
-            stack_trace: error
-                .stack_trace
-                .frames
-                .into_iter()
-                .map(|frame| Function {
-                    name: frame.function,
-                    file: frame.file,
-                    line: frame.line,
-                })
-                .collect(),
-        })
-        .collect())
+    Valgrind::new().analyze(path)
+}
+
+/// A `valgrind` command.
+///
+/// This type acts as a sentinel for a `valgrind` process. It allows the
+/// configuration via the `new()` function in a builder pattern style.
+#[derive(Debug)]
+pub struct Valgrind {
+    /// The valgrind command to execute.
+    valgrind: Command,
+}
+impl Valgrind {
+    /// Start configuring the valgrind command that will analyze the target.
+    pub fn new() -> Self {
+        Valgrind {
+            valgrind: Command::new("valgrind"),
+        }
+    }
+
+    /// Analyze the specified binary with the selected valgrind configuration.
+    ///
+    /// This function runs the program in valgrind, parses its XML output,
+    /// collects the leak information and returns the list of leaks. If this
+    /// list is empty, the program has no detected leaks.
+    ///
+    /// # Errors
+    /// This function returns an error, if valgrind could not be executed
+    /// successfully, its output could not be parsed correctly or any other
+    /// process related error occurs.
+    pub fn analyze<P: AsRef<Path>>(mut self, path: P) -> Result<Vec<Leak>, Error> {
+        Ok(self
+            .run_in_valgrind(path)?
+            .errors
+            .unwrap_or_default()
+            .into_iter()
+            .map(|error| Leak {
+                bytes: error.resources.bytes,
+                kind: error.kind,
+                stack_trace: error
+                    .stack_trace
+                    .frames
+                    .into_iter()
+                    .map(|frame| Function {
+                        name: frame.function,
+                        file: frame.file,
+                        line: frame.line,
+                    })
+                    .collect(),
+            })
+            .collect())
+    }
+
+    /// Run a binary inside `valgrind` and collect the report.
+    ///
+    /// This function launches a valgrind process, that does full leak checks
+    /// and reports all leak kinds in the XML format. The XML output is sent to
+    /// a local socket and then parsed into the `valgrind_xml::Output`
+    /// structure.
+    ///
+    /// # Errors
+    /// This function fails, if either the valgrind command couldn't be spawned
+    /// or executed successfully, the socket creation or read operation fails or
+    /// the received XML could not be parsed correctly.
+    fn run_in_valgrind<P: AsRef<Path>>(&mut self, path: P) -> Result<valgrind_xml::Output, Error> {
+        // port selected by OS
+        let address: SocketAddr = ([127, 0, 0, 1], 0).into();
+        let listener = TcpListener::bind(address)?;
+        let address = listener.local_addr()?;
+        let mut valgrind = self
+            .valgrind
+            .arg("--xml=yes")
+            .arg(format!("--xml-socket={}:{}", address.ip(), address.port()))
+            .arg(path.as_ref())
+            .spawn()?;
+        let (listener, _socket) = listener.accept()?;
+
+        if valgrind.wait()?.success() {
+            serde_xml_rs::from_reader(listener)
+                .map_err(|e| Error::new(ErrorKind::Other, format!("Could not parse XML: {}", e)))
+        } else {
+            Err(Error::new(ErrorKind::Other, "valgrind command failed"))
+        }
+    }
 }
 
 /// A single memory leak.
@@ -426,37 +491,6 @@ impl Display for Function {
             f.write_str(")")?;
         }
         Ok(())
-    }
-}
-
-/// Run a binary inside `valgrind` and collect the report.
-///
-/// This function launches a valgrind process, that does full leak checks and
-/// reports all leak kinds in the XML format. The XML output is sent to a local
-/// socket and then parsed into the `valgrind_xml::Output` structure.
-///
-/// # Errors
-/// This function fails, if either the valgrind command couldn't be spawned or
-/// executed successfully, the socket creation or read operation fails or the
-/// received XML could not be parsed correctly.
-fn run_in_valgrind<P: AsRef<Path>>(path: P) -> Result<valgrind_xml::Output, Error> {
-    let address: SocketAddr = ([127, 0, 0, 1], 0).into(); // port selected by OS
-    let listener = TcpListener::bind(address)?;
-    let address = listener.local_addr()?;
-    let mut valgrind = Command::new("valgrind")
-        .arg("--leak-check=full")
-        .arg("--show-leak-kinds=all")
-        .arg("--xml=yes")
-        .arg(format!("--xml-socket={}:{}", address.ip(), address.port()))
-        .arg(path.as_ref())
-        .spawn()?;
-    let (listener, _socket) = listener.accept()?;
-
-    if valgrind.wait()?.success() {
-        serde_xml_rs::from_reader(listener)
-            .map_err(|e| Error::new(ErrorKind::Other, format!("Could not parse XML: {}", e)))
-    } else {
-        Err(Error::new(ErrorKind::Other, "valgrind command failed"))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,10 @@ pub mod cargo_config {
 /// This function returns an error, if valgrind could not be executed
 /// successfully, its output could not be parsed correctly or any other process
 /// related error occurs.
+#[deprecated(
+    since = "1.2.0",
+    note = "Use the more flexible `Valgrind` type instead"
+)]
 pub fn valgrind<P: AsRef<Path>>(path: P) -> Result<Vec<Leak>, Error> {
     Valgrind::new().analyze(path)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,15 @@ impl Valgrind {
             .collect())
     }
 
+    /// Specify, whether all leaks or only a summary should be reported.
+    ///
+    /// Possible values are `"summary"` and `"full"`. Other values will cause
+    /// the valgrind command to fail.
+    pub fn set_leak_check(&mut self, kind: &str) -> &mut Self {
+        self.valgrind.arg(format!("--leak-check={}", kind));
+        self
+    }
+
     /// Run a binary inside `valgrind` and collect the report.
     ///
     /// This function launches a valgrind process, that does full leak checks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,6 +382,22 @@ impl Valgrind {
         self
     }
 
+    /// Specify the leak kinds to report.
+    ///
+    /// Possible values are `"definite"`, `"possible"`, `"reachable"` and
+    /// `"indirect"`. Other values will cause the valgrind command to fail.
+    pub fn set_leak_kinds(&mut self, kinds: &[&str]) -> &mut Self {
+        self.valgrind
+            .arg(format!("--show-leak-kinds={}", kinds.join(",")));
+        self
+    }
+
+    /// Report all leak kinds.
+    pub fn all_leak_kinds(&mut self) -> &mut Self {
+        self.valgrind.arg("--show-leak-kinds=all");
+        self
+    }
+
     /// Run a binary inside `valgrind` and collect the report.
     ///
     /// This function launches a valgrind process, that does full leak checks


### PR DESCRIPTION
This PR adds a new type `Valgrind`, similar to what #15 did. This is a step towards a more extensible crate, since there are no functions with changing signatures.
The old `valgrind` function is deprecated in favor of the new type.