### PR TITLE
Don't panic on crates with build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.2.1
+- Fixed panic if the crate under test contains a build script
+- Print an error if there are no runnable targets available
+
 ## Version 1.2.0
 - Support the valgrind parameter `--show-leak-kinds=<set>`
 - Support the valgrind parameter `--leak-check=<summary|full>`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-valgrind"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-valgrind"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Julian Frimmel <julian.frimmel@gmail.com>"]
 edition = "2018"
 description = "A cargo subcommand for running valgrind"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -186,6 +186,7 @@ fn find_target(specified: Option<Target>, targets: &[Target]) -> Result<Target> 
     let target = match specified {
         Some(path) => path,
         None if targets.len() == 1 => targets[0].clone(),
+        None if targets.is_empty() => Err("No runnable target found.")?,
         None => {
             let mut error = String::from("Multiple possible targets, please specify one of:\n");
             let targets: Vec<_> = targets

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -632,6 +632,7 @@ fn binaries_from<P: AsRef<Path>>(
                 .targets
                 .into_iter()
                 .filter(|target| target.crate_types.contains(&metadata::CrateType::Binary))
+                .filter(|target| target.kind[0] != metadata::Kind::CustomBuild)
                 .map(|target| {
                     let path = target_dir
                         .join(match target.kind[0] {


### PR DESCRIPTION
Previously the `cargo valgrind` was not aware of build scripts and panicked due to a missing implementation of a handler for them. This PR filters out build scripts, witch prevents the panics, but also makes running build scripts inside cargo valgrind impossible (which should be a very rare case).
Note, that this won't fix the panic, if the crate contains integration tests.

Fixes #21.