### PR TITLE
Better error message if valgrind executable is not found

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,7 +455,14 @@ impl Valgrind {
             .arg("--xml=yes")
             .arg(format!("--xml-socket={}:{}", address.ip(), address.port()))
             .arg(path.as_ref())
-            .spawn()?;
+            .spawn()
+            .map_err(|e| match e.kind() {
+                ErrorKind::NotFound => Error::new(
+                    e.kind(),
+                    format!("valgrind executable not found in `PATH` ({})", e),
+                ),
+                _ => e,
+            })?;
         let (listener, _socket) = listener.accept()?;
 
         if valgrind.wait()?.success() {


### PR DESCRIPTION
As stated in the [Readme](TODO), the user is required to have valgrind in his PATH. As described in #25 this is not always the case, especially if there are different user accounts, which use the program. Some of them may have valgrind in the PATH, some may not. Those users, who don't have valgrind directly available, currently see the following output:
```bash
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
   Analyzing `target/debug/binary`
error: No such file or directory (os error 2)
```
which doesn't tell, which file is not found and requires them to search for it.

This PR improves the error message to give the following output:
```bash
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
   Analyzing `target/debug/binary`
error: valgrind executable not found in `PATH` (No such file or directory (os error 2))
```
which exactly tells, what went wrong.

Closes #25.