### PR TITLE
Support user flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.3.0
+- Support user flags for the analyzed binary.
+
 ## Version 1.2.3
 - Updated dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-valgrind"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-valgrind"
-version = "1.2.3"
+version = "1.3.0"
 authors = ["Julian Frimmel <julian.frimmel@gmail.com>"]
 edition = "2018"
 description = "A cargo subcommand for running valgrind"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -81,6 +81,13 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
                         .value_name("FEATURES"),
                 )
                 .arg(
+                    Arg::with_name("user-flags")
+                        .help("Flags, that are passed to the analyzed binary")
+                        .last(true)
+                        .multiple(true)
+                        .value_name("[args]"),
+                )
+                .arg(
                     Arg::with_name("leak-check")
                         .help("Select, whether each leak or only a summary should be reported")
                         .long("leak-check")
@@ -115,13 +122,6 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
                                     .map_or(Ok(()), |s| Err(s.into()))
                             }
                         }),
-                )
-                .arg(
-                    Arg::with_name("user-flags")
-                        .help("Flags, that are passed to the analyzed binary")
-                        .last(true)
-                        .multiple(true)
-                        .value_name("[args]"),
                 ),
         )
 }
@@ -273,6 +273,7 @@ fn analyze_target(cli: &ArgMatches<'_>, target: &Target, manifest: &Path) -> Res
         }
         _ => {}
     }
+    valgrind.with_user_flags(cli.values_of("user-flags"));
     let errors = valgrind.analyze(target.real_path())?;
     if errors.is_empty() {
         Ok(Report::NoErrorDetected)

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -879,4 +879,47 @@ mod tests {
             assert!(cli().get_matches_from_safe(arguments.iter()).is_err());
         }
     }
+
+    mod user_flags {
+        use super::*;
+
+        #[test]
+        fn without() {
+            let arguments = [
+                "cargo-valgrind",
+                "valgrind",
+                "--show-leak-kinds",
+                "indirect",
+                "--",
+            ];
+            assert!(cli().get_matches_from_safe(arguments.iter()).is_ok());
+        }
+
+        #[test]
+        fn with_single() {
+            let arguments = [
+                "cargo-valgrind",
+                "valgrind",
+                "--show-leak-kinds",
+                "indirect",
+                "--",
+                "omg",
+            ];
+            assert!(cli().get_matches_from_safe(arguments.iter()).is_ok());
+        }
+
+        #[test]
+        fn with_multiple() {
+            let arguments = [
+                "cargo-valgrind",
+                "valgrind",
+                "--show-leak-kinds",
+                "indirect",
+                "--",
+                "omg",
+                "yeah",
+            ];
+            assert!(cli().get_matches_from_safe(arguments.iter()).is_ok());
+        }
+    }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -120,6 +120,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
                     Arg::with_name("user-flags")
                         .help("Flags, that are passed to the analyzed binary")
                         .last(true)
+                        .multiple(true)
                         .value_name("[args]"),
                 ),
         )

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -115,6 +115,12 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
                                     .map_or(Ok(()), |s| Err(s.into()))
                             }
                         }),
+                )
+                .arg(
+                    Arg::with_name("user-flags")
+                        .help("Flags, that are passed to the analyzed binary")
+                        .last(true)
+                        .value_name("[args]"),
                 ),
         )
 }


### PR DESCRIPTION
This PR introduces the ability to pass user flags to the analyzed binary after `--`, similar to what can be done with the normal `cargo run --`.

Closes #27.
Closes #19.