### PR TITLE
Automatically wrap text in long user output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,7 @@ dependencies = [
  "predicates",
  "serde",
  "serde-xml-rs",
+ "textwrap",
 ]
 
 [[package]]
@@ -276,6 +277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "syn"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,10 +294,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd05616119e612a8041ef58f2b578906cc2531a6069047ae092cfb86a325d835"
+dependencies = [
+ "smawk",
+ "terminal_size",
+ "unicode-width",
+]
+
+[[package]]
 name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ exclude = [
     "tests",
 ]
 
+[features]
+default = ["textwrap"]
+
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]
@@ -36,6 +39,11 @@ version = "1.8.0"
 
 [dependencies.bytesize]
 version = "1.0.0"
+
+[dependencies.textwrap]
+version = "*"
+optional = true
+features = ["terminal_size"]
 
 [dev-dependencies.assert_cmd]
 version = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
     let help_requested = || env::args_os().any(|arg| arg == "--help" || arg == "-h");
     let is_cargo_subcommand = || env::args_os().nth(1).map_or(false, |arg| arg == "valgrind");
     if number_of_arguments() == 0 || help_requested() {
-        println!(
+        let text = format!(
             "cargo valgrind {version}\n\
             {authors}\n\
             Analyze your Rust binary for memory errors\n\
@@ -45,6 +45,13 @@ fn main() {
             version = env!("CARGO_PKG_VERSION"),
             authors = env!("CARGO_PKG_AUTHORS").replace(':', ", "),
         );
+        #[cfg(feature = "textwrap")]
+        let text = textwrap::wrap(
+            &textwrap::dedent(&text).trim_start(),
+            textwrap::Options::with_termwidth(),
+        )
+        .join("\n");
+        println!("{}", text);
     } else if is_cargo_subcommand() {
         if !driver::driver().expect("Could not execute subcommand") {
             process::exit(200);

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -2,6 +2,19 @@
 
 use std::panic;
 
+const PANIC_HEADER: &str = "
+    Oooops. cargo valgrind unexpectedly crashed. This is a bug!
+
+    This is an error in this program, which should be fixed. If you can, please
+    submit a bug report at
+
+        https://github.com/jfrimmel/cargo-valgrind/issues/new/choose
+
+    To make fixing the error more easy, please provide the information below as
+    well as additional information on which project the error occurred or how
+    to reproduce it.
+    ";
+
 /// Replaces any previous hook with the custom hook of this application.
 ///
 /// This custom hook points the user to the project repository and asks them to
@@ -9,17 +22,16 @@ use std::panic;
 pub fn replace_hook() {
     let old_hook = panic::take_hook();
     panic::set_hook(Box::new(move |panic| {
-        eprintln!(
-            "Oooops. cargo valgrind unexpectedly crashed. This is a bug!\n\
-            \n\
-            This is an error in this program, which should be fixed. If you \
-            can, please submit a bug report at\n\
-            https://github.com/jfrimmel/cargo-valgrind/issues/new/choose\n\
-            \n\
-            To make fixing the error more easy, please provide the information \
-            below as well as additional information on which project the error \
-            occurred or how to reproduce it.\n"
-        );
+        #[cfg(not(feature = "textwrap"))]
+        let text = PANIC_HEADER;
+        #[cfg(feature = "textwrap")]
+        let text = textwrap::wrap(
+            &textwrap::dedent(PANIC_HEADER).trim_start(),
+            textwrap::Options::with_termwidth(),
+        )
+        .join("\n");
+        eprintln!("{}", text);
+
         old_hook(panic)
     }));
 }


### PR DESCRIPTION
This commit introduces a new, optional dependency on `textwrap`, which
is used for wrapping the panic and help messages, if the feature is
available.