### PR TITLE
More helpful panic message on invalid/unknown XML

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,9 @@ fn main() {
                 127
             }
             Ok(_) => 0,
+            Err(valgrind::Error::MalformedOutput(e)) => {
+                panic!("malformed or unexpected valgrind output: {}", e)
+            }
             Err(e) => {
                 eprintln!("{}: {}", "error".red().bold(), e);
                 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,8 +96,8 @@ fn main() {
                 127
             }
             Ok(_) => 0,
-            Err(valgrind::Error::MalformedOutput(e)) => {
-                panic!("malformed or unexpected valgrind output: {}", e)
+            Err(e @ valgrind::Error::MalformedOutput(..)) => {
+                panic_with!(e);
             }
             Err(e) => {
                 eprintln!("{}: {}", "error".red().bold(), e);

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -50,6 +50,12 @@ pub fn replace_hook() {
         .join("\n");
         eprintln!("{}", text);
 
+        eprintln!(
+            "{}: version {}",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION")
+        );
+
         if let Some(crate::valgrind::Error::MalformedOutput(e)) = panic.payload().downcast_ref() {
             eprintln!(
                 "XML format mismatch between `valgrind` and `cargo valgrind`: {}",

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -8,6 +8,7 @@
 //!
 //! [`Error::MalformedOutput`]: crate::valgrind::Error::MalformedOutput
 
+use crate::valgrind::Error;
 use std::panic;
 
 const PANIC_HEADER: &str = "
@@ -56,10 +57,16 @@ pub fn replace_hook() {
             env!("CARGO_PKG_VERSION")
         );
 
-        if let Some(crate::valgrind::Error::MalformedOutput(e)) = panic.payload().downcast_ref() {
+        // intentionally not wrapped using `textwrap`, since own formatting
+        // might be applied.
+        if let Some(Error::MalformedOutput(e, content)) = panic.payload().downcast_ref() {
             eprintln!(
                 "XML format mismatch between `valgrind` and `cargo valgrind`: {}",
                 e
+            );
+            eprintln!(
+                "XML output of valgrind:\n```xml\n{}```",
+                String::from_utf8_lossy(content)
             );
         } else {
             old_hook(panic)

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -13,14 +13,14 @@ use std::panic;
 const PANIC_HEADER: &str = "
     Oooops. cargo valgrind unexpectedly crashed. This is a bug!
 
-    This is an error in this program, which should be fixed. If you can, please
-    submit a bug report at
+    This is an error in this program, which should be fixed. If you can, \
+    please submit a bug report at
 
         https://github.com/jfrimmel/cargo-valgrind/issues/new/choose
 
-    To make fixing the error more easy, please provide the information below as
-    well as additional information on which project the error occurred or how
-    to reproduce it.
+    To make fixing the error more easy, please provide the information below \
+    as well as additional information on which project the error occurred or \
+    how to reproduce it.
     ";
 
 /// Panic with a custom panic output.


### PR DESCRIPTION
If the valgrind binary outputs anything, that `cargo-valgrind` cannot handle, there is an error output.
# Current state
Currently, that output looks like that:
```
error: unexpected valgrind output: custom: 'missing field `auxwhat`'
```
This looks like the run binary had an error or something. It is not immediately obvious, that there is an implementation error in `cargo-valgrind`.

# Proposed output
This PR changes the error output to a panic with a custom message:
```
Oooops. cargo valgrind unexpectedly crashed. This is a bug!

This is an error in this program, which should be fixed. If you can, please submit a
bug report at

    https://github.com/jfrimmel/cargo-valgrind/issues/new/choose

To make fixing the error more easy, please provide the information below as well as
additional information on which project the error occurred or how to reproduce it.

cargo-valgrind: version 2.0.1
XML format mismatch between `valgrind` and `cargo valgrind`: custom: 'missing field `auxwhat`'
XML output of valgrind:
<the XML content/>
```
Using this output, the user knows clearly, that there is a bug and that should be reported.

Fixes #40.