### PR TITLE
Add GitHub CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: Continous Integration
+on: pull_request
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  # build the crate on Linux, Windows and MacOS (can only be tested on Linux)
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: [stable, nightly]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      - name: Build
+        run: cargo build
+
+  # execute all tests (requires an installed valgrind)
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install valgrind
+        run: sudo apt install valgrind
+      - name: Run tests
+        run: cargo test

--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -1,0 +1,13 @@
+name: Minimum Supported Rust Version (MRSV)
+on: pull_request
+env:
+  CARGO_TERM_COLOR: always
+  MSRV: "1.51"
+jobs:
+  # build but don't test the crate with the Minimum Supported Rust Version
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup update $MSRV && rustup default $MSRV
+      - run: cargo check

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,0 +1,41 @@
+name: Style
+on: pull_request
+defaults:
+  run:
+    shell: bash
+jobs:
+  # Check correct formatting
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup update stable && rustup default stable
+      - run: rustup component add rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup update nightly && rustup default nightly
+      - run: rustup component add clippy-preview
+      - name: Run clippy lints
+        id: clippy
+        run: |
+          echo '# Output of `cargo clippy`' > clippy.output
+          echo '```' >> clippy.output
+          cargo clippy 2>&1 | tee -a clippy.output || true
+          echo '```' >> clippy.output
+          echo 'If your PR introduced these issues, please try to address them.' >> clippy.output
+          # the clippy exit code is ignored, therefore the build always works
+          echo "::set-output name=line_count::$(wc -l clippy.output | cut -f 1 -d ' ')"
+      - run: echo '${{ steps.clippy.outputs.line_count }}'
+      - run: wc -l clippy.output | cut -f 1 -d ' '
+      - name: Comment clippy output
+        if: ${{ steps.clippy.outputs.line_count > 6 }}
+        uses: machine-learning-apps/pr-comment@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: clippy.output


### PR DESCRIPTION
There are three workflows in place:
- the basic CI workflow, that builds the crate on multiple platforms and
  tests the program on linux (where valgrind can be easily installed)
- the MSRV test
- the style test (formatting and linting)