### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
           git config --global user.name 'GitHub Actions Release Bot'
       - name: Create release commit
         run: |
-          sed -i "s/^version = .*$/version = \"${VERSION}\"/" Cargo.toml
+          sed -i "0,/version = /{s/^version = .*$/version = \"${VERSION}\"/}" Cargo.toml
           cargo check
           git add Cargo.toml Cargo.lock
 


### PR DESCRIPTION
The previous workflow did replace all crate version fields with the new
version, including the dependencies. This commit changes it to only
alter the first version field, which should be `cargo-valgrind` (unless
somebody reorders the `Cargo.toml`).