### PR TITLE
Use `cargo version -v` instead of `rustc -vV` when obtaining host triple

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -3,7 +3,6 @@
 use std::env;
 use std::ffi::OsString;
 use std::io;
-use std::path::Path;
 use std::process::Command;
 
 /// The prefix line for the target host output.
@@ -18,18 +17,16 @@ const HOST_PREFIX: &[u8] = b"host: ";
 /// This function returns an I/O error, if a subprocess could not be spawned or
 /// executed.
 pub fn driver() -> io::Result<bool> {
-    /* get path of `rustc` */
     let cargo = env::var_os("CARGO").expect("CARGO environment variable is not set");
-    let rustc = Path::new(&cargo).with_file_name("rustc");
 
-    /* get the output of `rustc -vV` */
-    let rustc_info = Command::new(rustc).arg("-vV").output()?.stdout;
+    /* get the output of `cargo version -v` */
+    let rustc_info = Command::new(&cargo).args(&["version", "-v"]).output()?.stdout;
 
     /* get the host information (all after the "host: ..." line) */
     let host = rustc_info
         .windows(HOST_PREFIX.len())
         .position(|window| window == HOST_PREFIX)
-        .expect("Host information not present in `rustc -vV`");
+        .expect("Host information not present in `cargo version -v`");
     let host: String = rustc_info
         .into_iter()
         .skip(host)
@@ -39,13 +36,14 @@ pub fn driver() -> io::Result<bool> {
         .collect();
 
     /* convert to runner env variable */
-    let host = host.replace('-', "_").replace('.', "_").to_uppercase();
+    let host = host.replace(&['-', '.'], "_").to_uppercase();
     let runner = format!("CARGO_TARGET_{}_RUNNER", host);
 
     /* cargo run with a custom runner */
     let cargo_valgrind = env::args_os()
         .next()
         .unwrap_or_else(|| OsString::from("cargo-valgrind"));
+
     Ok(Command::new(cargo)
         .args(env::args_os().skip(2))
         .envs(env::vars_os())


### PR DESCRIPTION
This fixes an issue where rustc cannot be found since the cargo and rustc binaries are in separate directories.

You should probably fix the clippy lints!