### PR TITLE
Update CI definitions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,6 @@
 name: Continuos Integration
 on:
   push:
-    branches:
-      - master
-  pull_request:
 env:
   CARGO_TERM_COLOR: always
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install valgrind
         run: sudo apt install valgrind
       - name: Run tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install stable
       uses: dtolnay/rust-toolchain@stable
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust stable
       uses: dtolnay/rust-toolchain@stable
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -1,9 +1,6 @@
 name: Minimum Supported Rust Version (MRSV)
 on:
   push:
-    branches:
-      - master
-  pull_request:
 env:
   CARGO_TERM_COLOR: always
   MSRV: "1.51"

--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -12,6 +12,6 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: rustup update $MSRV && rustup default $MSRV
       - run: cargo check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Configure git user for Bot
         run: |
           git config --global user.email 'noreply@github.com'

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -12,7 +12,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable
       - run: rustup component add rustfmt
       - name: Check formatting

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,9 +1,6 @@
 name: Style
 on:
   push:
-    branches:
-      - master
-  pull_request:
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
- Update to the latest version of GitHub Actions checkout (v4)
- run CI workflows on push instead on pull requests