### PR TITLE
Install the deploy SSH keys

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,9 @@ jobs:
         run: |
           git config --global user.email 'noreply@github.com'
           git config --global user.name 'GitHub Actions Release Bot'
+          # install SSH-key from GitHub secrets
+          install -m 600 -D /dev/null ~/.ssh/id_rsa
+          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_rsa
       - name: Create release commit
         run: |
           sed -i "0,/version = /{s/^version = .*$/version = \"${VERSION}\"/}" Cargo.toml


### PR DESCRIPTION
The [latest release workflow] failed due to the branch protection rules, which prevents changes to the default branch without a pull request. The exception for deploy keys were not relevant, as there is no deploy key used as of now. Therefore this commit uses a newly added deploy SSH key (RSA).

[latest release workflow]: https://github.com/jfrimmel/cargo-valgrind/actions/runs/10904155821/job/30260156202