### PR TITLE
Install the deploy SSH keys

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: Configure git user for Bot
         run: |
           git config --global user.email 'noreply@github.com'


### PR DESCRIPTION
The [latest release workflow] failed due to the branch protection rules, which prevents changes to the default branch without a pull request. The exception for deploy keys were not relevant, as there is no deploy key used as of now. Therefore this commit uses a newly added deploy SSH key (RSA).

[latest release workflow]: https://github.com/jfrimmel/cargo-valgrind/actions/runs/10905905182/job/30265898820