### PR TITLE
Add proper stack overflow detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 /.vscode
+vgcore.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## unreleased
+- Add more helpful error message if the program under test overflows its stack ([#93](https://github.com/jfrimmel/cargo-valgrind/pull/93))
 
 ## Version 2.2.1
 - Ensure, that consistent tag names are used ([#89](https://github.com/jfrimmel/cargo-valgrind/pull/89)).

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,18 @@ fn main() {
             Err(e @ valgrind::Error::MalformedOutput(..)) => {
                 panic_with!(e);
             }
+            Err(valgrind::Error::ValgrindFailure(output))
+                if output.contains("main thread stack using the --main-stacksize= flag") =>
+            {
+                let error = "Error".red().bold();
+                let info = "Info".cyan().bold();
+                eprintln!("{:>12}: looks like the program overflowed its stack", error);
+                eprintln!("{:>12}: valgrind says:", info);
+                output
+                    .lines()
+                    .for_each(|line| eprintln!("              {}", line));
+                134 // default exit code for stack overflows
+            }
             Err(e) => {
                 eprintln!("{}: {}", "error".red().bold(), e);
                 1

--- a/tests/corpus/Cargo.toml
+++ b/tests/corpus/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 publish = false
 
 [[bin]]
+name = "issue-13"
+path = "issue-13.rs"
+
+[[bin]]
 name = "issue-74"
 path = "issue-74.rs"
 

--- a/tests/corpus/issue-13.rs
+++ b/tests/corpus/issue-13.rs
@@ -1,0 +1,7 @@
+fn stack_overflow() {
+    stack_overflow()
+}
+
+fn main() {
+    stack_overflow();
+}

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -27,6 +27,22 @@ fn duplicate_stack_fields() {
         ));
 }
 
+/// Issue: [#13]
+///
+/// [#13]: https://github.com/jfrimmel/cargo-valgrind/issues/13
+#[test]
+fn stack_overflow_in_program_under_test() {
+    cargo_valgrind()
+        .arg("run")
+        .args(TARGET_CRATE)
+        .arg("--bin=issue-13")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "looks like the program overflowed its stack",
+        ));
+}
+
 /// Issue: [#20]
 ///
 /// [#20]: https://github.com/jfrimmel/cargo-valgrind/issues/20


### PR DESCRIPTION
This commit checks for a specific valgrind output string occurring when a potential stack overflow is detected. The output is "parsed" a bit, in order to produces a nicer user experience. The output looks like this:
```text
$ cargo valgrind run --manifest-path tests/corpus/Cargo.toml --bin issue-13
   Error: looks like the program overflowed its stack
    Info: valgrind says:
          ==1937526== Stack overflow in thread #1: can't grow stack to 0x1ffe801000
          ==1937526== Stack overflow in thread #1: can't grow stack to 0x1ffe801000
          ==1937526== Stack overflow in thread #1: can't grow stack to 0x1ffe801000
          ==1937526==  If you believe this happened as a result of a stack
          ==1937526==  overflow in your program's main thread (unlikely but
          ==1937526==  possible), you can try to increase the size of the
          ==1937526==  main thread stack using the --main-stacksize= flag.
          ==1937526==  The main thread stack size used in this run was 8388608.
```
This clearly states the most likely cause of the error and thus helps a user to search the error. The actual valgrind output is written there as well, since it contains the help how to diagnose this more/mitigate a potential false positive by creating a bigger stack.

Fixes #13.