### PR TITLE
Follow-up to #77: make sure, that everything works with current MSRV

### DIFF
--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -5,10 +5,13 @@ env:
   CARGO_TERM_COLOR: always
   MSRV: "1.51"
 jobs:
-  # build but don't test the crate with the Minimum Supported Rust Version
+  # Build and test the tool with the Minimum Supported Rust Version
   msrv:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install valgrind
+        run: sudo apt install valgrind
       - run: rustup update $MSRV && rustup default $MSRV
-      - run: cargo check
+      - name: Run tests
+        run: cargo test

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -20,7 +20,10 @@ pub fn driver() -> io::Result<bool> {
     let cargo = env::var_os("CARGO").expect("CARGO environment variable is not set");
 
     /* get the output of `cargo version -v` */
-    let rustc_info = Command::new(&cargo).args(&["version", "-v"]).output()?.stdout;
+    let rustc_info = Command::new(&cargo)
+        .args(&["version", "-v"])
+        .output()?
+        .stdout;
 
     /* get the host information (all after the "host: ..." line) */
     let host = rustc_info

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -39,7 +39,7 @@ pub fn driver() -> io::Result<bool> {
         .collect();
 
     /* convert to runner env variable */
-    let host = host.replace(&['-', '.'], "_").to_uppercase();
+    let host = host.replace('-', "_").replace('.', "_").to_uppercase();
     let runner = format!("CARGO_TARGET_{}_RUNNER", host);
 
     /* cargo run with a custom runner */

--- a/tests/corpus/issue-74.rs
+++ b/tests/corpus/issue-74.rs
@@ -29,9 +29,9 @@ fn ex4() {
   let (a, b)
       = split_at_mut(r, 4);
 
-  println!("a={a:?} (should be [1, 2, 3, 4]");
+  println!("a={:?} (should be [1, 2, 3, 4]", a);
   drop(a);
-  println!("b={b:?} (should be [5, 6])");
+  println!("b={:?} (should be [5, 6])", b);
   // assert_eq!(a, &mut[1, 2, 3, 4]);
   // assert_eq!(b, &mut[5, 6]);
 }


### PR DESCRIPTION
While it makes sense to be able to build this project with old versions of Rust (and this is actually ensured), it also necessary to be able to _actually run_ the tool successfully. Therefore this commit introduces a fallback for older Rust versions, where `cargo` does not include the `host:`-field in the output (the 1.51 cargo outputs):
```text
cargo 1.51.0 (43b129a20 2021-03-16)
release: 1.51.0
commit-hash: 43b129a20fbf1ede0df411396ccf0c024bf34134
commit-date: 2021-03-16
```
This PR ensures, that the MSRV can actually run by running the tests in this repository with the MSRV-cargo as well.