### PR TITLE
Also run GitHub workflows on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: Continuos Integration
 on:
   push:
+  pull_request:
 env:
   CARGO_TERM_COLOR: always
 jobs:

--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -1,6 +1,7 @@
 name: Minimum Supported Rust Version (MRSV)
 on:
   push:
+  pull_request:
 env:
   CARGO_TERM_COLOR: always
   MSRV: "1.51"

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,6 +1,7 @@
 name: Style
 on:
   push:
+  pull_request:
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
I have the hope, that this will allow to run workflows from contributors submitting a pull request from a fork. This is a little bit annoying for myself, as pushes from this repository are built and then, when a PR is opened, everything is rebuilt. [Others face the same issue](https://github.com/orgs/community/discussions/26276#discussioncomment-3251151). 