### PR TITLE
Clean up the `Cargo.toml` manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,27 +26,13 @@ exclude = [
 [features]
 default = ["textwrap"]
 
-[dependencies.serde]
-version = "1"
-features = ["derive"]
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde-xml-rs = { version = "0.5", default-features = false }
+colored = "1.9.4"
+bytesize = "1"
+textwrap = { version = "0.14", optional = true, features = ["terminal_size"] }
 
-[dependencies.serde-xml-rs]
-version = "0.5"
-default-features = false
-
-[dependencies.colored]
-version = "1.9.4"
-
-[dependencies.bytesize]
-version = "1"
-
-[dependencies.textwrap]
-version = "0.14"
-optional = true
-features = ["terminal_size"]
-
-[dev-dependencies.assert_cmd]
-version = "2"
-
-[dev-dependencies.predicates]
-version = "2"
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ categories = [
     "development-tools::cargo-plugins",
 ]
 exclude = [
+    ".github",
+    ".vscode",
     "CHANGELOG.md",
     "tests",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = [
     "cargo",
-    "subcomand",
+    "subcommand",
     "cargo-subcommand",
     "valgrind",
     "cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,23 +7,9 @@ description = "A cargo subcommand for running valgrind"
 repository = "https://github.com/jfrimmel/cargo-valgrind"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
-keywords = [
-    "cargo",
-    "subcommand",
-    "cargo-subcommand",
-    "valgrind",
-    "cli",
-]
-categories = [
-    "development-tools",
-    "development-tools::cargo-plugins",
-]
-exclude = [
-    ".github",
-    ".vscode",
-    "CHANGELOG.md",
-    "tests",
-]
+keywords = ["cargo", "subcommand", "cargo-subcommand", "valgrind", "cli"]
+categories = ["development-tools", "development-tools::cargo-plugins"]
+exclude = [".github", ".vscode", "CHANGELOG.md", "tests"]
 
 [features]
 default = ["textwrap"]


### PR DESCRIPTION
* [Use more concise way of specifying dependencies](https://github.com/jfrimmel/cargo-valgrind/commit/4fb4b0617cb03c1187bd8757b6bac123ae60052a)
* [Fix spelling of `subcommand`](https://github.com/jfrimmel/cargo-valgrind/commit/5857cb1195c2c8ee25889bd31ce3482714f1a426)
* [Exclude some directories from published artifact](https://github.com/jfrimmel/cargo-valgrind/commit/eedf5b8f3da2b476badf5f039e82c7bc82b524fc)
* [Format `Cargo.toml`](https://github.com/jfrimmel/cargo-valgrind/commit/6569c2b5b5800e10523df66525aa84aed9e05583)

No functional changes intended :wink: 