### PR TITLE
Install valgrind in beta compiler test

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -14,6 +14,8 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@v4
+      - name: Install valgrind
+        run: sudo apt install valgrind
       - run: rustup update beta && rustup default beta
       - name: Compile the code with the beta compiler
         id: build-beta


### PR DESCRIPTION
Without valgrind installed, executing the tests will obviously fail, so the first (any up to now only) run of the [workflow] created issue #113 due to test failures caused by missing valgrind.

[workflow]: https://github.com/jfrimmel/cargo-valgrind/actions/runs/12452939892/job/34762500879

Fixes #113.