### PR TITLE
Make sure, that apt-based installations work

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install valgrind
-        run: sudo apt install valgrind
+        run: sudo apt-get update && sudo apt-get install valgrind
       - run: rustup update beta && rustup default beta
       - name: Compile the code with the beta compiler
         id: build-beta

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install valgrind
-        run: sudo apt install valgrind
+        run: sudo apt-get update && sudo apt-get install valgrind
       - run: rustup update --no-self-update 1.82 && rustup default 1.82
       - name: Run tests
         run: cargo test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Install musl
       if: contains(matrix.target, 'linux-musl')
       run: |
-        sudo apt-get install musl-tools
+        sudo apt-get update && sudo apt-get install musl-tools
 
     - name: Build cargo-valgrind
       run: |

--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install valgrind
-        run: sudo apt install valgrind
+        run: sudo apt-get update && sudo apt-get install valgrind
       - run: rustup update $MSRV && rustup default $MSRV
       - name: Run tests
         run: cargo test


### PR DESCRIPTION
As detected on the periodic beta-test-job, the installation of valgrind may fail. This is caused by not running `apt-get update` beforehand. While doing this change, the non-stable CLI of `apt` is replaced with the stable `apt-get`.