### PR TITLE
Remove hashes in Valgrind suppressions

### DIFF
--- a/suppressions/rust-1.83
+++ b/suppressions/rust-1.83
@@ -16,7 +16,7 @@
    fun:do_call<std::rt::lang_start_internal::{closure_env#0}, ()>
    fun:try<(), std::rt::lang_start_internal::{closure_env#0}>
    fun:catch_unwind<std::rt::lang_start_internal::{closure_env#0}, ()>
-   fun:_ZN3std2rt19lang_start_internal17h1c66660c99c8424cE
-   fun:_ZN3std2rt10lang_start17h6a655fabb2038567E
+   fun:_ZN3std2rt19lang_start_internal*
+   fun:_ZN3std2rt10lang_start*
    fun:main
 }

--- a/suppressions/rust-1.86
+++ b/suppressions/rust-1.86
@@ -9,7 +9,7 @@
    fun:{closure#0}<std::thread::Inner>
    fun:allocate_for_layout<core::mem::maybe_uninit::MaybeUninit<std::thread::Inner>, alloc::sync::{impl#14}::new_uninit::{closure_env#0}<std::thread::Inner>, fn(*mut u8) -> *mut alloc::sync::ArcInner<core::mem::maybe_uninit::MaybeUninit<std::thread::Inner>>>
    fun:new_uninit<std::thread::Inner>
-   fun:_ZN3std6thread6Thread3new17hfefd1c7ad06cf00aE
-   fun:_ZN3std6thread7current12init_current17h3c2a16458c19e8ecE
+   fun:_ZN3std6thread6Thread3new*
+   fun:_ZN3std6thread7current12init_current*
    fun:current_or_unnamed
 }


### PR DESCRIPTION
Apparently, the hashes in the mangled function names are different in each build of Rust (e.g. Rust 1.86.0-beta.5 and 1.86.0-beta.7 produce different ones, 1.87.0 has different ones again). Therefore the hashes get replaced with a wildcard in this commit.
This makes the suppressions applicable for all Rust 1.86 betas as well as 1.86.0 itself.

Fixes #123.