### PR TITLE
Update suppression list for recent nightly

### DIFF
--- a/suppressions/rust-1.86
+++ b/suppressions/rust-1.86
@@ -7,7 +7,7 @@
    fun:alloc_impl
    fun:allocate
    fun:{closure#0}<std::thread::Inner>
-   fun:allocate_for_layout<core::mem::maybe_uninit::MaybeUninit<std::thread::Inner>, alloc::sync::{impl#14}::new_uninit::{closure_env#0}<std::thread::Inner>, fn(*mut u8) -> *mut alloc::sync::ArcInner<core::mem::maybe_uninit::MaybeUninit<std::thread::Inner>>>
+   fun:allocate_for_layout<core::mem::maybe_uninit::MaybeUninit<std::thread::Inner>, alloc::sync::{impl#*}::new_uninit::{closure_env#0}<std::thread::Inner>, fn(*mut u8) -> *mut alloc::sync::ArcInner<core::mem::maybe_uninit::MaybeUninit<std::thread::Inner>>>
    fun:new_uninit<std::thread::Inner>
    fun:_ZN3std6thread6Thread3new*
    fun:_ZN3std6thread7current12init_current*


### PR DESCRIPTION
Not sure what stdlib change caused this, but I'm seeing `impl#16` instead of `impl#14` in recent nightlies, see e.g. [this CI job](https://github.com/iex-rs/lithium/actions/runs/18269820778/job/52010343643).