### PR TITLE
Remove hashes from Rust 1.93 suppression

### DIFF
--- a/suppressions/rust-1.93
+++ b/suppressions/rust-1.93
@@ -9,7 +9,7 @@
    fun:{closure#0}<std::thread::thread::Inner, std::alloc::System>
    fun:allocate_for_layout<core::mem::maybe_uninit::MaybeUninit<std::thread::thread::Inner>, alloc::sync::{impl#*}::new_uninit_in::{closure_env#0}<std::thread::thread::Inner, std::alloc::System>, fn(*mut u8) -> *mut alloc::sync::ArcInner<core::mem::maybe_uninit::MaybeUninit<std::thread::thread::Inner>>>
    fun:new_uninit_in<std::thread::thread::Inner, std::alloc::System>
-   fun:_RNvMs_NtNtCsjSkZfQkjc54_3std6thread6threadNtB4_6Thread3new
-   fun:_RNvNtNtCsjSkZfQkjc54_3std6thread7current12init_current
+   fun:_RNvMs_NtNtCs*_3std6thread6threadNtB4_6Thread3new
+   fun:_RNvNtNtCs*_3std6thread7current12init_current
    fun:current_or_unnamed
 }


### PR DESCRIPTION
Totally missed this during the previous PR due to the mangling change, sorry. The previous patch only worked for the specific `std` version that was published at the moment.