### PR TITLE
README.md: Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This will install the latest official released version.
 
 If you want to use the latest changes, that were not yet published to `crates.io`, you can install the binary from the git-repository like this:
 ```bash
-$ cargo install --git https://github.com/jfrimmel/cargo-valgrind
+$ cargo install --git https://github.com/jfrimmel/cargo-valgrind cargo-valgrind
 ```
 
 # License


### PR DESCRIPTION
This was failing as there are multiple binary packages available and `cargo` doesn't know which one to install

```
$ cargo install --git https://github.com/jfrimmel/cargo-valgrind
    Updating git repository `https://github.com/jfrimmel/cargo-valgrind`
error: multiple packages with binaries found: cargo-valgrind, corpus, ffi-bug, program-aborts. When installing a git repository, cargo will always search the entire repo for any Cargo.toml.
Please specify a package, e.g. `cargo install --git https://github.com/jfrimmel/cargo-valgrind cargo-valgrind`
```